### PR TITLE
Update main.lua | Removed Blip Duplicate Entry

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -460,18 +460,6 @@ local function spawnListVehicle(model)
     SetVehicleEngineOn(veh, true, true, false)
 end
 
-local function createBlip()
-    local blip = AddBlipForCoord(sharedConfig.locations.exit.x, sharedConfig.locations.exit.y, sharedConfig.locations.exit.z)
-    SetBlipSprite(blip, 446)
-    SetBlipDisplay(blip, 4)
-    SetBlipScale(blip, 0.7)
-    SetBlipColour(blip, 0)
-    SetBlipAsShortRange(blip, true)
-    BeginTextCommandSetBlipName("STRING")
-    AddTextComponentString(locale('labels.job_blip'))
-    EndTextCommandSetBlipName(blip)
-end
-
 -- Events
 
 AddEventHandler('onResourceStart', function(resource)


### PR DESCRIPTION
Blips for mechanic shops all are created in qbx_customs, there is no need for the "AutoCare Mechanic" to be created, and either way, it only creates a blip at the main los santos mechanic shop, due to its config, it also would need removal in the json files for the locales :         "job_blip": "Autocare Mechanic",

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? --> Yes, it indeed fixes an issue, it should be merged as its a miscellaneous small bug, but even a small change can be a big difference. 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
![Screenshot 2024-12-12 021742](https://github.com/user-attachments/assets/426e6d1a-d2fb-413f-a343-444622074586)
![Screenshot 2024-12-12 021806](https://github.com/user-attachments/assets/8ab78d45-8ed8-4461-9627-2236b9542e6c)
