### PR TITLE
fix: Job durty check after enter or exit

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -534,9 +534,7 @@ end
 
 RegisterNetEvent('QBCore:Client:OnJobUpdate', updateJobActions)
 
-RegisterNetEvent('QBCore:Client:SetDuty', function()
-    updateJobActions()
-end)
+RegisterNetEvent('QBCore:Client:SetDuty', updateJobActions)
 
 RegisterNetEvent('qb-vehicletuning:client:SetAttachedVehicle', function(veh, key)
     sharedConfig.plates[key].AttachedVehicle = veh

--- a/client/main.lua
+++ b/client/main.lua
@@ -522,7 +522,8 @@ local function updateJobActions()
     deleteTarget(dutyTargetBoxId)
     deleteTarget(stashTargetBoxId)
     
-
+     Wait(2000) -- wait 2s to preventing bug on zone creation interator
+    
     if QBX.PlayerData.job.type == 'mechanic' then
         registerDutyTarget()
     

--- a/client/main.lua
+++ b/client/main.lua
@@ -532,9 +532,7 @@ local function updateJobActions()
     end
 end
 
-RegisterNetEvent('QBCore:Client:OnJobUpdate', function()
-   updateJobActions()
-end)
+RegisterNetEvent('QBCore:Client:OnJobUpdate', updateJobActions)
 
 RegisterNetEvent('QBCore:Client:SetDuty', function()
     updateJobActions()

--- a/client/main.lua
+++ b/client/main.lua
@@ -518,28 +518,25 @@ AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
     end)
 end)
 
-RegisterNetEvent('QBCore:Client:OnJobUpdate', function()
+local function updateJobActions()
     deleteTarget(dutyTargetBoxId)
     deleteTarget(stashTargetBoxId)
+    
 
-    if QBX.PlayerData.type ~= 'mechanic' then return end
+    if QBX.PlayerData.job.type == 'mechanic' then
+        registerDutyTarget()
+    
+        if not QBX.PlayerData.job.onduty then return end
+        registerStashTarget()
+    end
+end
 
-    registerDutyTarget()
-
-    if not QBX.PlayerData.job.onduty then return end
-    registerStashTarget()
+RegisterNetEvent('QBCore:Client:OnJobUpdate', function()
+   updateJobActions()
 end)
 
 RegisterNetEvent('QBCore:Client:SetDuty', function()
-    deleteTarget(dutyTargetBoxId)
-    deleteTarget(stashTargetBoxId)
-
-    if QBX.PlayerData.type == 'mechanic' then
-    registerDutyTarget()
-
-    if not QBX.PlayerData.job.onduty then return end
-    registerStashTarget()
-    end
+    updateJobActions()
 end)
 
 RegisterNetEvent('qb-vehicletuning:client:SetAttachedVehicle', function(veh, key)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

This PR corrects the way of checking whether the player entered or left the service, in the original code the property accessed in the QBX.PlayerData table was wrong, I also put the code in a function since it is repeated in two places.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ x ] My pull request fits the contribution guidelines & code conventions.
