### PR TITLE
fix: secure mechanic server events

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -324,7 +324,9 @@ local function checkStatus()
 end
 
 local function repairPart(part)
-    local hasEnough = lib.callback.await('qbx_mechanicjob:server:checkForItems', false, part)
+    local veh = sharedConfig.plates[closestPlate].AttachedVehicle
+    local plate = qbx.getVehiclePlate(veh)
+    local hasEnough = lib.callback.await('qbx_mechanicjob:server:checkForItems', false, part, plate)
     if not hasEnough then
         local itemName = sharedConfig.repairCostAmount[part].item
         local amountRequired = sharedConfig.repairCostAmount[part].costs
@@ -344,8 +346,6 @@ local function repairPart(part)
         }
     }) then
         exports.scully_emotemenu:cancelEmote()
-        local veh = sharedConfig.plates[closestPlate].AttachedVehicle
-        local plate = qbx.getVehiclePlate(veh)
         if part == "engine" then
             SetVehicleEngineHealth(veh, sharedConfig.maxStatusValues[part])
             TriggerServerEvent("vehiclemod:server:updatePart", plate, "engine", sharedConfig.maxStatusValues[part])

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,7 +1,10 @@
 local config = require 'config.server'
+local clientConfig = require 'config.client'
 local sharedConfig = require 'config.shared'
 local vehicleStatus = {}
 local vehicleDrivingDistance = {}
+local repairAuthorizations = {}
+local vehiclesSpawning = {}
 local stash = {
     id = 'mechanicstash',
     label = locale('labels.stash'),
@@ -36,6 +39,52 @@ local function isAuthorized(citizenId)
     return false
 end
 
+---@param plate any
+---@return string?
+local function normalizePlate(plate)
+    if type(plate) ~= 'string' or #plate > 16 then return end
+    return plate:match('^%s*(.-)%s*$')
+end
+
+---@param source number
+---@return Player?
+local function getOnDutyMechanic(source)
+    local player = exports.qbx_core:GetPlayer(source)
+    if player and player.PlayerData.job.type == 'mechanic' and player.PlayerData.job.onduty then return player end
+end
+
+---@param source number
+---@param plate string
+---@return number?
+local function getCurrentVehicle(source, plate)
+    local vehicle = GetVehiclePedIsIn(GetPlayerPed(source), false)
+    if vehicle == 0 or not DoesEntityExist(vehicle) then return end
+    if normalizePlate(GetVehicleNumberPlateText(vehicle)) ~= plate then return end
+    return vehicle
+end
+
+---@param source number
+---@param plate string
+---@return number?
+local function getLiftVehicle(source, plate)
+    local playerCoords = GetEntityCoords(GetPlayerPed(source))
+    for i = 1, #sharedConfig.plates do
+        local lift = sharedConfig.plates[i]
+        local vehicle = lift.AttachedVehicle
+        if vehicle and DoesEntityExist(vehicle)
+            and #(playerCoords - lift.coords.xyz) <= 8.0
+            and normalizePlate(GetVehicleNumberPlateText(vehicle)) == plate
+        then
+            return vehicle
+        end
+    end
+end
+
+local function isValidLevel(part, level)
+    local maxLevel = sharedConfig.maxStatusValues[part]
+    return maxLevel and type(level) == 'number' and level == level and level >= 0 and level <= maxLevel
+end
+
 -- Callbacks
 
 lib.callback.register('qb-vehicletuning:server:GetDrivingDistances', function()
@@ -50,22 +99,33 @@ lib.callback.register('qb-vehicletuning:server:GetAttachedVehicle', function()
     return sharedConfig.plates
 end)
 
-lib.callback.register('qbx_mechanicjob:server:spawnVehicle', function(source, vehicleName, vehicleCoords)
+lib.callback.register('qbx_mechanicjob:server:spawnVehicle', function(source, vehicleName)
+	if not getOnDutyMechanic(source) or vehiclesSpawning[source] or type(vehicleName) ~= 'string' or not clientConfig.vehicles[vehicleName] then return end
+	if #(GetEntityCoords(GetPlayerPed(source)) - sharedConfig.locations.vehicle.xyz) > 10.0 then return end
+	vehiclesSpawning[source] = true
 	local netId = qbx.spawnVehicle({
         model = joaat(vehicleName),
-        spawnSource = vehicleCoords,
+        spawnSource = sharedConfig.locations.vehicle,
         warp = GetPlayerPed(source)
     })
+	vehiclesSpawning[source] = nil
 	return netId
 end)
 
-lib.callback.register('qbx_mechanicjob:server:checkForItems', function(source, part)
-    local itemName = sharedConfig.repairCostAmount[part].item
-    local amountRequired = sharedConfig.repairCostAmount[part].costs
+lib.callback.register('qbx_mechanicjob:server:checkForItems', function(source, part, suppliedPlate)
+    local plate = normalizePlate(suppliedPlate)
+    local repairCost = type(part) == 'string' and sharedConfig.repairCostAmount[part]
+    if not plate or not repairCost or not getOnDutyMechanic(source) or not getLiftVehicle(source, plate) then return false end
+
+    local itemName = repairCost.item
+    local amountRequired = repairCost.costs
     local amount = exports.ox_inventory:Search(source, 'count', itemName)
     local hasEnough = amount >= amountRequired
     if hasEnough then
-        exports.ox_inventory:RemoveItem(source, itemName, amountRequired)
+        hasEnough = exports.ox_inventory:RemoveItem(source, itemName, amountRequired) == true
+        if hasEnough then
+            repairAuthorizations[source] = { plate = plate, part = part, expires = os.time() + 30 }
+        end
     end
     return hasEnough
 end)
@@ -73,14 +133,21 @@ end)
 -- Events
 
 RegisterNetEvent('qb-vehicletuning:server:SaveVehicleProps', function(vehicleProps)
-    if not isVehicleOwned(vehicleProps.plate) then return end
+    if type(vehicleProps) ~= 'table' then return end
+    local plate = normalizePlate(vehicleProps.plate)
+    if not plate or not getCurrentVehicle(source, plate) or not isVehicleOwned(plate) then return end
 
-    MySQL.update.await('UPDATE player_vehicles SET mods = ? WHERE plate = ?', {json.encode(vehicleProps), vehicleProps.plate})
+    vehicleProps.plate = plate
+    MySQL.update.await('UPDATE player_vehicles SET mods = ? WHERE plate = ?', {json.encode(vehicleProps), plate})
 end)
 
 RegisterNetEvent('vehiclemod:server:setupVehicleStatus', function(plate, engineHealth, bodyHealth)
-    engineHealth = engineHealth or 1000.0
-    bodyHealth = bodyHealth or 1000.0
+    plate = normalizePlate(plate)
+    if not plate or not getCurrentVehicle(source, plate) then return end
+    if type(engineHealth) ~= 'number' or engineHealth ~= engineHealth then engineHealth = 1000.0 end
+    if type(bodyHealth) ~= 'number' or bodyHealth ~= bodyHealth then bodyHealth = 1000.0 end
+    engineHealth = math.max(0, math.min(1000, engineHealth))
+    bodyHealth = math.max(0, math.min(1000, bodyHealth))
 
     local statusInfo = vehicleStatus[plate] or getVehicleStatus(plate) or
         {
@@ -98,6 +165,16 @@ RegisterNetEvent('vehiclemod:server:setupVehicleStatus', function(plate, engineH
 end)
 
 RegisterNetEvent('qb-vehicletuning:server:UpdateDrivingDistance', function(amount, plate)
+    plate = normalizePlate(plate)
+    local vehicle = plate and getCurrentVehicle(source, plate)
+    if not vehicle or GetPedInVehicleSeat(vehicle, -1) ~= GetPlayerPed(source)
+        or type(amount) ~= 'number' or amount ~= amount or amount < 0 or amount > 1000000000
+    then
+        return
+    end
+    local previous = vehicleDrivingDistance[plate]
+    if previous and (amount < previous or amount - previous > 10000) then return end
+    if not previous and isVehicleOwned(plate) and amount > 10000 then return end
     vehicleDrivingDistance[plate] = amount
     TriggerClientEvent('qb-vehicletuning:client:UpdateDrivingDistance', -1, vehicleDrivingDistance[plate], plate)
     local result = MySQL.query.await('SELECT plate FROM player_vehicles WHERE plate = ?', {plate})
@@ -107,27 +184,46 @@ RegisterNetEvent('qb-vehicletuning:server:UpdateDrivingDistance', function(amoun
 end)
 
 RegisterNetEvent('qb-vehicletuning:server:LoadStatus', function(veh, plate) -- Used in old qb-garages
+    plate = normalizePlate(plate)
+    if not plate or type(veh) ~= 'table' or not getCurrentVehicle(source, plate) then return end
     vehicleStatus[plate] = veh
     TriggerClientEvent("vehiclemod:client:setVehicleStatus", -1, plate, veh)
 end)
 
 RegisterNetEvent('vehiclemod:server:updatePart', function(plate, part, level)
-    if not vehicleStatus[plate] then return end
+    plate = normalizePlate(plate)
+    if not plate or type(part) ~= 'string' or not vehicleStatus[plate] or not isValidLevel(part, level) then return end
 
-    local maxLevel = (part == "engine" or part == "body") and 1000 or 100
-    vehicleStatus[plate][part] = level < 0 and 0 or level > maxLevel and maxLevel or level
+    local currentLevel = vehicleStatus[plate][part]
+    if type(currentLevel) ~= 'number' then return end
+    if level > currentLevel then
+        local authorization = repairAuthorizations[source]
+        if not getOnDutyMechanic(source) or not getLiftVehicle(source, plate)
+            or not authorization or authorization.plate ~= plate or authorization.part ~= part or authorization.expires < os.time()
+        then
+            return
+        end
+        repairAuthorizations[source] = nil
+    elseif not getCurrentVehicle(source, plate) and not getLiftVehicle(source, plate) then
+        return
+    end
+
+    vehicleStatus[plate][part] = level
     TriggerClientEvent("vehiclemod:client:setVehicleStatus", -1, plate, vehicleStatus[plate])
 end)
 
 RegisterNetEvent('qb-vehicletuning:server:SetPartLevel', function(plate, part, level)
-    if not vehicleStatus[plate] then return end
+    plate = normalizePlate(plate)
+    if not plate or type(part) ~= 'string' or not vehicleStatus[plate] or not isValidLevel(part, level) or not getCurrentVehicle(source, plate) then return end
+    if type(vehicleStatus[plate][part]) ~= 'number' or level > vehicleStatus[plate][part] then return end
 
     vehicleStatus[plate][part] = level
     TriggerClientEvent("vehiclemod:client:setVehicleStatus", -1, plate, vehicleStatus[plate])
 end)
 
 RegisterNetEvent('vehiclemod:server:fixEverything', function(plate)
-    if not vehicleStatus[plate] then return end
+    plate = normalizePlate(plate)
+    if not plate or not vehicleStatus[plate] or not IsPlayerAceAllowed(source, 'group.admin') or not getCurrentVehicle(source, plate) then return end
 
     for k, v in pairs(sharedConfig.maxStatusValues) do
         vehicleStatus[plate][k] = v
@@ -137,16 +233,25 @@ RegisterNetEvent('vehiclemod:server:fixEverything', function(plate)
 end)
 
 RegisterNetEvent('vehiclemod:server:saveStatus', function(plate) -- Used in old qb-garages
-    if not vehicleStatus[plate] then return end
+    plate = normalizePlate(plate)
+    if not plate or not vehicleStatus[plate] or not getCurrentVehicle(source, plate) then return end
 
     MySQL.update.await('UPDATE player_vehicles SET status = ? WHERE plate = ?', { json.encode(vehicleStatus[plate]), plate })
 end)
 
 RegisterNetEvent('qb-vehicletuning:server:SetAttachedVehicle', function(k, veh)
-    if not sharedConfig.plates[k] then return end
+    if math.type(k) ~= 'integer' or not sharedConfig.plates[k] or not getOnDutyMechanic(source) then return end
+    local lift = sharedConfig.plates[k]
+    if #(GetEntityCoords(GetPlayerPed(source)) - lift.coords.xyz) > 8.0 then return end
+    if veh ~= false and (type(veh) ~= 'number' or not DoesEntityExist(veh) or #(GetEntityCoords(veh) - lift.coords.xyz) > 8.0) then return end
 
-    sharedConfig.plates[k].AttachedVehicle = veh
+    lift.AttachedVehicle = veh
     TriggerClientEvent('qb-vehicletuning:client:SetAttachedVehicle', -1, veh, k)
+end)
+
+AddEventHandler('playerDropped', function()
+    repairAuthorizations[source] = nil
+    vehiclesSpawning[source] = nil
 end)
 
 -- Commands


### PR DESCRIPTION
Restricts job vehicle spawning and lift actions; binds repair consumption to vehicle/part authorizations; validates plates, levels, distance, and persistence. Validation: git diff --check.